### PR TITLE
Teach the Makefile to sail with both docker compose fleets ☠️⛵️

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
         exclude: package.lock.json
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,18 @@ COMPOSE_UP_OPTIONS    ?= --build --force-recreate --pull always
 COMPOSE_LOGS_OPTIONS  ?= --follow
 
 #
+# Docker Compose command compatible with 'docker compose' (v2) and 'docker-compose' (v1).
+#
+DOCKER_COMPOSE := $(shell if docker compose version >/dev/null 2>&1; then echo "docker compose"; elif command -v docker-compose >/dev/null 2>&1; then echo "docker-compose"; else echo ""; fi)
+
+ifeq ($(DOCKER_COMPOSE),)
+  $(error "Neither 'docker compose' nor 'docker-compose' is available. Please install Docker Compose.")
+endif
+
+#
 # Build dependencies
 #
-DEPENDENCIES=docker docker-compose
+DEPENDENCIES=docker
 
 #
 # Path to Dockerfile
@@ -59,13 +68,15 @@ $(ALL): $(UP)
 $(BUILD_DEPENDS):
 	$(foreach exe,$(DEPENDENCIES), \
 		$(if $(shell which $(exe) 2> /dev/null),,$(error "No $(exe) in PATH")))
+	@# Verify Docker Compose availability (supports both 'docker compose' and 'docker-compose')
+	@$(DOCKER_COMPOSE) version >/dev/null 2>&1 || (echo "Docker Compose not found. Install 'docker compose' or 'docker-compose'." && exit 1)
 
 #
 # $(DOWN): Stops containers and removes containers, networks, volumes, and images created by up.
 #
 $(DOWN): $(BUILD_DEPENDS)
 	@echo "\nStopping service $(COMPOSE_SERVICE_NAME)"
-	docker-compose down $(COMPOSE_DOWN_OPTIONS)
+	$(DOCKER_COMPOSE) down $(COMPOSE_DOWN_OPTIONS)
 
 	@echo "\nRemoving images based on $(FROM_IMAGE)"
 	@docker images -q "$(FROM_IMAGE)" | xargs -r docker rmi -f || true
@@ -77,7 +88,7 @@ $(DOWN): $(BUILD_DEPENDS)
 #
 $(BUILD): $(BUILD_DEPENDS)
 	@echo "\nBuilding service $(COMPOSE_SERVICE_NAME)"
-	docker-compose build $(COMPOSE_BUILD_OPTIONS) $(COMPOSE_SERVICE_NAME)
+	$(DOCKER_COMPOSE) build $(COMPOSE_BUILD_OPTIONS) $(COMPOSE_SERVICE_NAME)
 
 #
 # $(UP): Builds, (re)creates, and starts containers for services.
@@ -86,14 +97,14 @@ $(BUILD): $(BUILD_DEPENDS)
 #
 $(UP): $(BUILD_DEPENDS)
 	@echo "\nStarting service $(COMPOSE_SERVICE_NAME)"
-	docker-compose up $(COMPOSE_UP_OPTIONS)
+	$(DOCKER_COMPOSE) up $(COMPOSE_UP_OPTIONS)
 
 #
 # $(LOGS): View output from containers.
 #
 $(LOGS):
 	@echo "\nGetting logs for service $(COMPOSE_SERVICE_NAME)"
-	docker-compose logs $(COMPOSE_LOGS_OPTIONS)
+	$(DOCKER_COMPOSE) logs $(COMPOSE_LOGS_OPTIONS)
 
 #
 # $(HELP): Print help information.


### PR DESCRIPTION
## Teach the Makefile to sail with both docker compose fleets ☠️⛵️

This update lets the Makefile work with both `docker compose` and `docker-compose`. Some systems use the new v2 command. Others still use v1. The Makefile now checks which one you have and uses it.

### What changed
- Added logic to detect the right compose command
- Updated calls to use the detected command
- Removed strict need for `docker-compose` in PATH
- Added a check to stop if no compose command exists

### How to test
Run these to see which version you have

```bash
docker compose version
docker-compose version
```

Pull the latest code. Run these to verify it works

```bash
make up
make down
```

If the ship sails without errors, you are good. Smooth seas for all hands aboard 🏴‍☠️