### PR TITLE
Patch image dependency vulnerabilities ☠️

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,8 @@ ARG ALPINE_TAG=latest
 #
 ARG PIA_BIN_HOME=/pia
 ARG PRIVATEERR_BIN_HOME=/privateerr
+ARG JQ_APK_REPOSITORY=https://dl-cdn.alpinelinux.org/alpine/edge/main
+ARG JQ_APK_MIN_VERSION=1.8.2-r0
 ARG IMAGE_CREATED=unknown
 ARG IMAGE_REVISION=unknown
 ARG IMAGE_VERSION=latest
@@ -66,15 +68,19 @@ COPY privateerr-entrypoint.sh ${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh
 # writing the WireGuard config and metadata that Gluetun will consume.
 # openresolv provides the resolvconf command that PIA's scripts check when
 # PIA_DNS=true, even though Privateerr only writes a config file.
+# jq is installed from the configured package repository until Alpine stable
+# includes a version that fixes known 1.8.1-r0 vulnerabilities.
 #
 RUN apk add --no-cache \
       bash \
       ca-certificates \
       coreutils \
       curl \
-      jq \
       openresolv \
       wireguard-tools && \
+    apk add --no-cache \
+      --repository="${JQ_APK_REPOSITORY}" \
+      "jq>=${JQ_APK_MIN_VERSION}" && \
     chmod +x "${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh"
 
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ LABEL org.opencontainers.image.title="Privateerr" \
 #
 COPY pia-manual-connections ${PIA_BIN_HOME}
 COPY privateerr-entrypoint.sh ${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh
+COPY privateerr-date.sh /usr/local/bin/date
 
 #
 # Install only the tools required to generate PIA manual WireGuard configs.
@@ -68,20 +69,22 @@ COPY privateerr-entrypoint.sh ${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh
 # writing the WireGuard config and metadata that Gluetun will consume.
 # openresolv provides the resolvconf command that PIA's scripts check when
 # PIA_DNS=true, even though Privateerr only writes a config file.
+# A tiny date compatibility shim replaces the need for GNU coreutils.
 # jq is installed from the configured package repository until Alpine stable
 # includes a version that fixes known 1.8.1-r0 vulnerabilities.
 #
 RUN apk add --no-cache \
       bash \
       ca-certificates \
-      coreutils \
       curl \
       openresolv \
       wireguard-tools && \
     apk add --no-cache \
       --repository="${JQ_APK_REPOSITORY}" \
       "jq>=${JQ_APK_MIN_VERSION}" && \
-    chmod +x "${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh"
+    chmod +x \
+      "${PRIVATEERR_BIN_HOME}/privateerr-entrypoint.sh" \
+      /usr/local/bin/date
 
 #
 # Set the working directory to the PIA scripts install location.

--- a/docker/privateerr-date.sh
+++ b/docker/privateerr-date.sh
@@ -15,11 +15,20 @@
 #   - Delegates every other argument to BusyBox date.
 #
 
+#
+# Set strict error handling to exit on errors and treat unset variables as errors.
+#
 set -eu
 
+#
+# Initialize variables to hold the date value and additional arguments.
+#
 date_value=""
 date_args=""
 
+#
+# Parse command-line arguments to extract the date value and any additional arguments.
+#
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --date=*)
@@ -38,11 +47,17 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+#
+# If no date value is provided, delegate to BusyBox date with the accumulated arguments.
+#
 if [ -z "${date_value}" ]; then
     # shellcheck disable=SC2086
     eval "exec /bin/date ${date_args}"
 fi
 
+#
+# Handle specific date formats and convert them to a format compatible with BusyBox date.
+#
 case "${date_value}" in
     "1 day")
         date_value="@$(($(/bin/date +%s) + 86400))"
@@ -52,5 +67,8 @@ case "${date_value}" in
         ;;
 esac
 
+#
+# Finally, execute BusyBox date with the processed date value and any additional arguments.
+#
 # shellcheck disable=SC2086
 eval "exec /bin/date -d '$(printf '%s\n' "${date_value}" | sed "s/'/'\\\\''/g")' ${date_args}"

--- a/docker/privateerr-date.sh
+++ b/docker/privateerr-date.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# privateerr-date.sh: This script provides the small GNU date compatibility
+#                     surface needed by the upstream PIA scripts on Alpine.
+#
+# The script:
+#   - Accepts GNU-style '--date=VALUE' and '--date VALUE' arguments.
+#   - Supports the PIA token expiration value '1 day'.
+#   - Converts common ISO timestamps into a BusyBox date-compatible format.
+#   - Delegates every other argument to BusyBox date.
+#
+
+set -eu
+
+date_value=""
+date_args=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --date=*)
+            date_value="${1#--date=}"
+            shift
+            ;;
+        --date)
+            shift
+            date_value="${1:-}"
+            shift
+            ;;
+        *)
+            date_args="${date_args} $(printf '%s\n' "$1" | sed "s/'/'\\\\''/g; s/.*/'&'/")"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "${date_value}" ]; then
+    # shellcheck disable=SC2086
+    eval "exec /bin/date ${date_args}"
+fi
+
+case "${date_value}" in
+    "1 day")
+        date_value="@$(($(/bin/date +%s) + 86400))"
+        ;;
+    *T*Z)
+        date_value="$(printf '%s\n' "${date_value}" | sed 's/T/ /; s/Z$//')"
+        ;;
+esac
+
+# shellcheck disable=SC2086
+eval "exec /bin/date -d '$(printf '%s\n' "${date_value}" | sed "s/'/'\\\\''/g")' ${date_args}"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -56,8 +56,7 @@ LABEL org.opencontainers.image.title="Buccaneerr" \
 RUN apk add --no-cache \
       bash \
       ca-certificates \
-      curl \
-      jq
+      curl
 
 #
 # Copy over the Buccaneerr script and make it executable.

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ Buccaneerr checks the important loot:
 - The stack behaves like the downstream Synology-friendly Compose setup.
 
 > [!IMPORTANT]
-> ⚓ Buccaneerr exists so the main Privateerr image can stay wee, clean, and focused. Test tools like `curl` and `jq` stay in this image instead of clutterin' the production brig.
+> ⚓ Buccaneerr exists so the main Privateerr image can stay wee, clean, and focused. Test tools like `curl` stay in this image instead of clutterin' the production brig.
 
 ## How It Gets Built 🛠️
 


### PR DESCRIPTION
## What changed? ⚓

This PR fixes the Docker Scout `jq 1.8.1-r0` findings by updating Privateerr to install `jq>=1.8.2-r0` from Alpine edge main until Alpine stable carries the fixed package.

It also fixes the `coreutils 9.11-r0` finding by removing GNU coreutils from the Privateerr image and adding a tiny Alpine-compatible `date` shim for the GNU-style `date` calls used by the upstream PIA scripts.

Buccaneerr also drops unused `jq`, because the validator only needs `curl` for its current checks.

## Why? 🧭

Docker Scout reported vulnerabilities against `apk / alpine / jq / 1.8.1-r0` and `apk / alpine / coreutils / 9.11-r0`. Privateerr still needs `jq` to parse PIA server metadata, but it does not need the full GNU coreutils package just to support the PIA script date calls.

## Validation 🧪

From a clean local Docker state:

- `make nuke`
- `make build`
- `make build-buccaneerr`
- `make test-e2e`
- `make test-down`
- `docker run --rm --entrypoint sh ghcr.io/scottgigawatt/privateerr:latest -c 'date +"%c" --date="1 day" >/tmp/date-one-day && date -d @1234567890 >/tmp/date-epoch && date --date="2026-06-23T11:28:14Z" >/tmp/date-iso && jq --version && if apk info -e coreutils >/dev/null 2>&1; then echo coreutils-installed; exit 1; else echo coreutils-not-installed; fi'` -> `jq-1.8.2`, `coreutils-not-installed`
- `docker run --rm --entrypoint sh ghcr.io/scottgigawatt/buccaneerr:latest -c 'if command -v jq >/dev/null 2>&1; then jq --version; else echo jq-not-installed; fi'` -> `jq-not-installed`
- `make help`
- `make config`
- `make env`
- `pre-commit run --all-files`

## Notes 🏴‍☠️

Docker Scout CLI verification was not run because Docker Scout requires Docker login in this environment.
