### PR TITLE
Add GHCR descriptions to multi-arch manifests 📜

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -141,6 +141,11 @@ jobs:
                   push: true
                   tags: ${{ steps.meta-privateerr.outputs.tags }}
                   labels: ${{ steps.meta-privateerr.outputs.labels }}
+                  annotations: |
+                      index:org.opencontainers.image.title=Privateerr
+                      index:org.opencontainers.image.description=Privateerr generates PIA WireGuard configs and Gluetun metadata from unmodified PIA manual connection scripts.
+                      index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
+                      index:org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
                   build-args: |
                       ALPINE_TAG=latest
                       PIA_BIN_HOME=/pia
@@ -161,6 +166,11 @@ jobs:
                   push: true
                   tags: ${{ steps.meta-buccaneerr.outputs.tags }}
                   labels: ${{ steps.meta-buccaneerr.outputs.labels }}
+                  annotations: |
+                      index:org.opencontainers.image.title=Buccaneerr
+                      index:org.opencontainers.image.description=Test-only Buccaneerr validator for Privateerr, Gluetun WireGuard, and PIA port-forwarding e2e checks.
+                      index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
+                      index:org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
                   build-args: |
                       ALPINE_TAG=latest
                       BUCCANEERR_BIN_HOME=/buccaneerr


### PR DESCRIPTION
## What changed? 📜

This PR adds OCI index annotations to the multi-arch publish steps for Privateerr and Buccaneerr.

## Why? 🧭

GHCR reads package descriptions from the multi-arch manifest list annotations. Dockerfile labels still exist on the platform images, but the top-level `latest` package page can show "No description provided" without the index-level annotation.

## Validation 🧪

- `pre-commit run --all-files`
