### PR TITLE
Trim barnacles from the env scroll 🦜

### DIFF
--- a/example.env
+++ b/example.env
@@ -31,9 +31,7 @@ IMAGE_REVISION="${IMAGE_REVISION:-unknown}"
 PRIVATEERR_CONFIG_PATH="${PRIVATEERR_CONFIG_PATH:-./config/privateerr}"
 PRIVATEERR_GLUETUN_CONFIG_PATH="${PRIVATEERR_GLUETUN_CONFIG_PATH:-./config/gluetun}"
 
-#
 # Privateerr service PIA manual connection environment variables.
-#
 PIA_VPN_PROTOCOL="${PIA_VPN_PROTOCOL:-wireguard}"
 PIA_DISABLE_IPV6="${PIA_DISABLE_IPV6:-yes}"
 PIA_DIP_TOKEN="${PIA_DIP_TOKEN:-no}"
@@ -46,9 +44,7 @@ PIA_WG_SERVER_NAME="${PIA_WG_SERVER_NAME:-}"
 PIA_USER="${PIA_USER:-p1234567}"
 PIA_PASS="${PIA_PASS:-shiverMeTimbers123}"
 
-#
 # Privateerr service Privateerr environment variables.
-#
 PRIVATEERR_METADATA_PATH="${PRIVATEERR_METADATA_PATH:-/gluetun/wireguard/privateerr.env}"
 PRIVATEERR_HEALTHCHECK_MARKER="${PRIVATEERR_HEALTHCHECK_MARKER:-/healthcheck/privateerr.ready}"
 PRIVATEERR_KEEPALIVE="${PRIVATEERR_KEEPALIVE:-true}"


### PR DESCRIPTION
## What changed? 🧹

This PR trims extra comment wrapper lines from `example.env` so the env scroll stays cleaner and easier to scan.

## Validation 🧪

- `pre-commit run --all-files`
