### PR TITLE
Fix Docker Hub username lookup for Skopeo mirror

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -167,7 +167,7 @@ jobs:
               env:
                   GHCR_USERNAME: ${{ github.actor }}
                   GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+                  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
                   DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
                   GHCR_IMAGE_REF: ${{ env.PRIVATEERR_IMAGE_REF }}
                   DOCKERHUB_IMAGE_REF: ${{ env.DOCKERHUB_PRIVATEERR_IMAGE_REF }}
@@ -229,7 +229,7 @@ jobs:
             - name: "Update Privateerr Docker Hub overview 📘"
               uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae  # v4.0.0
               with:
-                  username: ${{ vars.DOCKERHUB_USERNAME }}
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
                   repository: ${{ github.repository_owner }}/privateerr
                   short-description: "Generate Private Internet Access WireGuard config and Gluetun metadata using PIA's unmodified scripts."

--- a/docs/ADVANCED_USAGE.md
+++ b/docs/ADVANCED_USAGE.md
@@ -85,7 +85,7 @@ Configure these GitHub Actions values before enabling Docker Hub publishing:
 
 | 🔐 Type | 🧾 Name | 🎯 Purpose |
 | --- | --- | --- |
-| Variable | `DOCKERHUB_USERNAME` | Docker Hub username used to log in. |
+| Secret | `DOCKERHUB_USERNAME` | Docker Hub username used to log in. |
 | Secret | `DOCKERHUB_TOKEN` | Docker Hub access token used by GitHub Actions. |
 
 The Docker Hub repository overview is updated by the same workflow from [DOCKERHUB_README.md](./DOCKERHUB_README.md). Keep that file shorter than the GitHub README: Docker Hub readers usually need to know what the image does, how to pull it, what platforms it supports, and where the full project docs live.


### PR DESCRIPTION
## Summary
- read DOCKERHUB_USERNAME from repository secrets instead of repository variables
- update Advanced Usage to match the repository secret setup

## Why
The publish workflow failed in the Skopeo mirror step with `username can't be empty` because the repository has `DOCKERHUB_USERNAME` configured as a secret, while the workflow was reading `vars.DOCKERHUB_USERNAME`.

## Validation
- pre-commit run actionlint --files .github/workflows/build-and-push.yml
- pre-commit run check-yaml --files .github/workflows/build-and-push.yml