### PR TITLE
Add CodeQL Actions baseline workflow

### DIFF
--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,43 @@
+name: "Interrogate the Actions Rigging 🔎🏴‍☠️"
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/**"
+            - ".github/actions/**"
+            - ".github/dependabot.yml"
+    pull_request:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/**"
+            - ".github/actions/**"
+            - ".github/dependabot.yml"
+    workflow_dispatch:
+
+jobs:
+    codeql-actions:
+        name: "Sniff the Workflow Bilge 🔍"
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+
+        steps:
+            - name: "Grab the Treasure Map 🗺️"
+              uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+
+            - name: "Wake the CodeQL Kraken 🐙"
+              uses: github/codeql-action/init@v4
+              with:
+                  languages: actions
+
+            - name: "Read the Cursed Scrolls 📜"
+              uses: github/codeql-action/analyze@v4
+              with:
+                  category: "/language:actions"

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
     codeql-actions:
-        name: "Analyze (actions)"
+        name: "Sniff the Workflow Bilge 🔍"
         runs-on: ubuntu-latest
         permissions:
             actions: read

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,43 @@
+name: "Interrogate the Actions Rigging 🔎🏴‍☠️"
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/**"
+            - ".github/actions/**"
+            - ".github/dependabot.yml"
+    pull_request:
+        branches:
+            - main
+        paths:
+            - ".github/workflows/**"
+            - ".github/actions/**"
+            - ".github/dependabot.yml"
+    workflow_dispatch:
+
+jobs:
+    codeql-actions:
+        name: "Analyze (actions)"
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+
+        steps:
+            - name: "Grab the Treasure Map 🗺️"
+              uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+
+            - name: "Wake the CodeQL Kraken 🐙"
+              uses: github/codeql-action/init@v4
+              with:
+                  languages: actions
+
+            - name: "Read the Cursed Scrolls 📜"
+              uses: github/codeql-action/analyze@v4
+              with:
+                  category: "/language:actions"


### PR DESCRIPTION
## What changed

Added explicit CodeQL workflow for GitHub Actions scanning.

## Why

GitHub code scanning reported missing `main` configuration for `/language:actions`, so Dependabot PRs could not compare introduced workflow alerts against a baseline.

## Impact

Merging this lets `main` publish the Actions CodeQL baseline. Future workflow-only Dependabot PRs can compare code scanning results normally.

## Validation

- `pre-commit run --files .github/workflows/codeql-actions.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql-actions.yml"); puts "yaml ok"'`

## Note

`make test-config` was requested by local approved commands but this repo has no `test-config` target.