### PR TITLE
Teach Renovate every Alpine pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,9 +16,24 @@
         "git-submodules",
         "github-actions"
     ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)Dockerfile$/",
+                "/^\\.github/workflows/.*\\.ya?ml$/"
+            ],
+            "matchStrings": [
+                "ALPINE_TAG[=:]\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "depNameTemplate": "alpine",
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
+        }
+    ],
     "packageRules": [
         {
-            "matchManagers": ["docker-compose", "dockerfile"],
+            "matchManagers": ["docker-compose", "dockerfile", "custom.regex"],
             "pinDigests": true
         },
         {

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -4,17 +4,9 @@ on:
     push:
         branches:
             - main
-        paths:
-            - ".github/workflows/**"
-            - ".github/actions/**"
-            - ".github/dependabot.yml"
     pull_request:
         branches:
             - main
-        paths:
-            - ".github/workflows/**"
-            - ".github/actions/**"
-            - ".github/dependabot.yml"
     workflow_dispatch:
 
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,14 @@ repos:
     hooks:
       - id: shellcheck
 
+  - repo: local
+    hooks:
+      - id: check-alpine-tag-pins
+        name: check Alpine tag pins
+        entry: test/check-alpine-tag-pins.sh
+        language: script
+        pass_filenames: false
+
   - repo: https://github.com/hadolint/hadolint
     rev: v2.14.0
     hooks:

--- a/test/check-alpine-tag-pins.sh
+++ b/test/check-alpine-tag-pins.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# check-alpine-tag-pins.sh: Verify every pinned Alpine build arg sails in formation.
+#
+
+#
+# Fail on any error, unset variable, or failed pipe command.
+#
+set -euo pipefail
+
+#
+# Shared Alpine build arg values must stay identical across Dockerfiles and
+# workflow build args so Renovate cannot leave one hull behind.
+#
+alpine_tag_values="$(
+    find .github/workflows docker test -type f \
+        \( -name '*.yml' -o -name '*.yaml' -o -name 'Dockerfile' \) \
+        -exec grep -Eh 'ALPINE_TAG[=:][[:space:]]*[^[:space:]]+@sha256:[a-f0-9]+' {} + \
+        | sed -E 's/.*ALPINE_TAG[=:][[:space:]]*//g' \
+        | sort -u
+)"
+alpine_tag_count="$(printf '%s\n' "${alpine_tag_values}" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+
+if [[ "${alpine_tag_count}" -eq 0 ]]; then
+    echo "No pinned ALPINE_TAG values found. The cargo hold is suspiciously empty."
+    exit 1
+fi
+
+if [[ "${alpine_tag_count}" -ne 1 ]]; then
+    echo "Mismatched pinned ALPINE_TAG values found:"
+    printf '%s\n' "${alpine_tag_values}" | sed 's/^/  /'
+    exit 1
+fi


### PR DESCRIPTION
## What changed

- Added a Renovate regex custom manager for `ALPINE_TAG=...@sha256:...` and `ALPINE_TAG: ...@sha256:...` values in Dockerfiles and workflows.
- Included the regex manager in digest pinning rules.
- Added a local pre-commit guard that fails when pinned Alpine build args drift apart.

## Why

Renovate updated only one Dockerfile `ARG` in #25 and missed the duplicate build arg plus workflow build args. This makes future Alpine updates hit every pinned value and adds a CI/pre-commit tripwire if anything is missed.

## Validation

- `test/check-alpine-tag-pins.sh`
- `SKIP=hadolint-docker pre-commit run --all-files`
- `npx --yes --package renovate@latest renovate-config-validator .github/renovate.json5`

## Note

`hadolint-docker` was skipped because the local Docker daemon is offline.