### PR TITLE
🏷️ Keep latest stable and send main to the edge

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
     build-and-push:
         name: "Pack the Cargo Hold 🧰"
+        if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -163,7 +164,31 @@ jobs:
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
               with:
                   submodules: recursive
+                  fetch-depth: 0
                   persist-credentials: false
+
+            - name: "Inspect the Release Chart 🧭"
+              if: startsWith(github.ref, 'refs/tags/')
+              env:
+                  RELEASE_TAG: ${{ github.ref_name }}
+              run: |
+                  semver_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|([0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))(\.((0|[1-9][0-9]*)|([0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+                  if [[ ! "${RELEASE_TAG}" =~ ${semver_pattern} ]]; then
+                    echo "Release tag ${RELEASE_TAG} is not valid semantic versioning."
+                    exit 1
+                  fi
+
+                  if [ "$(git cat-file -t "refs/tags/${RELEASE_TAG}")" != "tag" ]; then
+                    echo "Release tag ${RELEASE_TAG} must be annotated."
+                    exit 1
+                  fi
+
+                  git fetch --no-tags origin main
+                  if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+                    echo "Release tag ${RELEASE_TAG} does not point to a commit on main."
+                    exit 1
+                  fi
 
             - name: "Summon Cross-Arch Cannons 🧨"
               uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
@@ -237,9 +262,10 @@ jobs:
               uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
               with:
                   images: ${{ env.PRIVATEERR_IMAGE_REF }}
+                  flavor: |
+                      latest=auto
                   tags: |
-                      type=raw,value=latest,enable={{is_default_branch}}
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                      type=edge,branch=main
                       type=sha,prefix=sha-
                       type=semver,pattern={{version}}
 
@@ -248,9 +274,10 @@ jobs:
               uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
               with:
                   images: ${{ env.BUCCANEERR_IMAGE_REF }}
+                  flavor: |
+                      latest=auto
                   tags: |
-                      type=raw,value=latest,enable={{is_default_branch}}
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                      type=edge,branch=main
                       type=sha,prefix=sha-
                       type=semver,pattern={{version}}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,12 @@ repos:
         language: script
         pass_filenames: false
 
+      - id: check-image-tag-policy
+        name: check image tag policy
+        entry: test/check-image-tag-policy.sh
+        language: script
+        pass_filenames: false
+
   - repo: https://github.com/hadolint/hadolint
     rev: v2.14.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,268 @@
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# AGENTS.md: Contributor and AI-agent operating instructions for Privateerr.
+#
+
+# AGENTS.md
+
+## Project Purpose
+
+Privateerr packages the official, unmodified [PIA manual connection scripts](https://github.com/pia-foss/manual-connections) into a small Docker image that generates a WireGuard config file and Gluetun metadata.
+
+Privateerr is not a VPN client. It does not establish or maintain a VPN tunnel. It generates `config/gluetun/wireguard/wg0.conf` and `config/gluetun/wireguard/privateerr.env` so Gluetun or another WireGuard-capable VPN client can use them.
+
+The companion Buccaneerr image is test-only. It validates the Privateerr + Gluetun flow, including PIA WireGuard port forwarding.
+
+## Repository Layout
+
+- `docker/`: Privateerr image build context and Privateerr-owned entrypoint scripts.
+- `docker/pia-manual-connections/`: PIA upstream scripts as a git submodule. Treat this as third-party code.
+- `test/`: Buccaneerr image build context, e2e validator scripts, and example reset files.
+- `config/`: Checked-in service config directories used by Docker Compose.
+- `config/gluetun/wireguard/`: Generated WireGuard config and metadata location.
+- `docs/`: Supporting project documentation.
+- `.github/`: Workflows, issue templates, PR template, Dependabot, and CODEOWNERS.
+- `docker-compose.yml`: Single Compose stack used for local development, Synology-style one-file deployments, and e2e validation.
+- `example.env`: Complete example environment file. Keep ordering aligned with `docker-compose.yml`.
+
+## Code Ownership Boundaries
+
+Do not edit `docker/pia-manual-connections/` unless the explicit task is to update or manage the upstream submodule.
+
+Privateerr-owned code wraps the upstream scripts but should keep transparency clear:
+
+- PIA scripts should remain visibly upstream and unmodified.
+- Privateerr scripts should clearly show where they invoke PIA scripts.
+- Logs from wrapper scripts should identify which script produced each line.
+
+## Documentation Voice
+
+Public-facing Markdown uses the project voice: funny, pirate-themed, readable, and useful.
+
+Use pirate humor in:
+
+- `README.md`
+- files under `docs/`
+- config-directory README files
+- GitHub issue templates
+- GitHub PR templates
+- user-facing Makefile `echo` output when appropriate
+
+Do not let jokes obscure operational meaning. Commands, paths, warnings, examples, and troubleshooting details must remain precise.
+
+Use GitHub callouts where they help:
+
+- `[!NOTE]`
+- `[!TIP]`
+- `[!IMPORTANT]`
+- `[!WARNING]`
+- `[!CAUTION]`
+
+## Code Comment Style
+
+Inline code comments must be plain English, not pirate-themed.
+
+Comments should explain intent, constraints, and non-obvious behavior. Avoid narrating obvious assignments or shell syntax.
+
+Top-of-file comments for project-owned scripts and config-style files should include:
+
+- copyright line
+- Apache-2.0 license note
+- short filename summary
+- short bullet list when usage or behavior needs context
+
+Shell scripts with a shebang should have one blank line after the shebang before the top-of-file comment.
+
+## Shell Script Rules
+
+Project-owned host scripts should prefer:
+
+- `#!/bin/sh`
+- POSIX-compatible syntax
+- four-space indentation
+
+Container-only scripts may use Bash when the container image intentionally installs Bash and the Dockerfile/Compose entrypoint expects it.
+
+Keep shell error messages clear enough to diagnose failures quickly. User-facing status logs may use the project voice, but actual diagnostic errors should be direct.
+
+## Docker Rules
+
+Dockerfiles should be professional and registry-friendly:
+
+- include OCI labels
+- keep images small
+- avoid unused packages
+- explain required packages with concise plain-English comments
+- keep PIA scripts unmodified
+- use Alpine unless there is a strong reason to change
+
+Use architecture-neutral base images. Do not hardcode arch-specific image names such as `arm64v8/alpine`.
+
+Multi-architecture support is handled by GitHub Actions and Docker Buildx. Current supported platforms are:
+
+- `linux/amd64`
+- `linux/arm64`
+- `linux/arm/v7`
+
+For multi-arch images, GHCR package descriptions require index-level OCI annotations in workflow build steps, not only Dockerfile labels.
+
+## Docker Compose Rules
+
+This project intentionally uses one main `docker-compose.yml` file. Synology DSM Container Manager compatibility is a core constraint.
+
+Compose conventions:
+
+- keep service image names fixed when possible
+- keep image tags configurable through `.env`
+- define defaults in `.env` / `example.env`, not inline Compose fallback syntax
+- use YAML anchors for reusable labels or healthcheck settings
+- mount directories, not individual generated config files
+- group environment variables by owner/purpose
+- list PIA script variables before Privateerr-specific wrapper variables
+- keep `example.env` ordered to match the Compose service environment blocks
+
+Privateerr and Gluetun both mount `./config/gluetun` because Privateerr writes files that Gluetun consumes.
+
+## Generated Files And Secrets
+
+Live runs overwrite:
+
+- `config/gluetun/wireguard/wg0.conf`
+- `config/gluetun/wireguard/privateerr.env`
+
+Never commit real generated secrets. Restore checked-in examples with:
+
+```sh
+make reset-config
+```
+
+The source example files live in:
+
+- `test/examples/example-wg0.conf`
+- `test/examples/example-privateerr.env`
+
+Use "example files" terminology. Do not call these dummy files.
+
+## Makefile Rules
+
+Keep Makefile variables centralized near the top. Prefer variables for:
+
+- target names
+- service names
+- Docker Compose options
+- Docker Buildx options
+- reusable commands
+- generated paths
+
+Target comments should include dependencies using this format:
+
+```make
+#
+# $(TARGET): Short target description.
+#
+# Dependencies:
+#   $(OTHER_TARGET) - Why this dependency is needed.
+#
+```
+
+User-facing Makefile output may be pirate-themed, but should still explain what is happening.
+
+Important commands:
+
+```sh
+make help
+make build
+make build-buccaneerr
+make build-multiarch
+make run-privateerr
+make test-e2e
+make test-down
+make reset-config
+make clean
+make nuke
+make config
+make env
+make print-config
+make print-env
+```
+
+Run `make test-down` after live e2e tests to stop containers and restore example files.
+
+## GitHub Workflow Rules
+
+Workflow step names should be pirate-themed and include tasteful emoji.
+
+Use current major versions of GitHub Actions where practical.
+
+Build/publish behavior:
+
+- PR validation should build images and validate Compose without requiring PIA credentials.
+- Full live e2e should only run when credentials are available.
+- Main/tag publishing builds multi-arch images.
+- Release tags use git tags like `v0.1.0`.
+- Docker image semver tags omit the leading `v`, e.g. `0.1.0`.
+- `latest` and the semver image tag for a release should be produced from the same build output.
+
+Security/scanning:
+
+- keep Trivy scanning in workflows
+- keep Dependabot configuration current
+- keep OpenSSF / best-practice metadata current where present
+- keep provenance/SBOM enabled unless there is a specific reason not to
+
+Expect GHCR to show `unknown/unknown` entries for attestation manifests. Those are metadata artifacts, not runnable OS images.
+
+## Validation Expectations
+
+For small documentation-only changes, run:
+
+```sh
+pre-commit run --all-files
+```
+
+For Docker or workflow changes, run as applicable:
+
+```sh
+make help
+make config
+make build
+make build-buccaneerr
+make build-multiarch
+pre-commit run --all-files
+```
+
+For behavior changes touching Privateerr, Gluetun handoff, WireGuard config generation, or port forwarding, run:
+
+```sh
+make test-e2e
+make test-down
+```
+
+Do not leave live generated VPN config or metadata in the working tree.
+
+## Branch And PR Conventions
+
+Use funny pirate-themed branch names when creating feature branches. Do not prefix branch names with `codex-` unless explicitly requested.
+
+Commit messages may be funny and pirate-themed, with emoji, but they should still describe the change.
+
+PR descriptions should lead with the main functional change, then summarize quality-of-repo improvements concisely.
+
+## Licensing
+
+Privateerr project-owned files are Apache-2.0.
+
+The upstream PIA scripts are third-party code under their own license. Keep license boundaries clear and do not imply Privateerr relicenses the upstream submodule.
+
+## Operational Priorities
+
+Primary deployment target: Synology DSM Container Manager.
+
+Secondary development target: macOS with Docker Desktop.
+
+Preserve one-file Compose compatibility for Synology. Avoid modular Compose designs that require multiple Compose files at runtime.
+
+Prefer simple, maintainable automation over clever abstractions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-#
-# Copyright 2025-2026 Scott Gigawatt
-#
-# Licensed under the Apache License, Version 2.0.
-#
-# AGENTS.md: Contributor and AI-agent operating instructions for Privateerr.
-#
+<!--
+  Copyright 2025-2026 Scott Gigawatt
+
+  Licensed under the Apache License, Version 2.0.
+
+  AGENTS.md: Contributor and AI-agent operating instructions for Privateerr.
+  -->
 
 # AGENTS.md
 

--- a/README.md
+++ b/README.md
@@ -216,12 +216,14 @@ The image builds from Alpine for a small footprint. Alpine is not a distro PIA l
 
 Published Privateerr images support `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
 
-Images are published to both GHCR and Docker Hub:
+Images are published to both GHCR and Docker Hub. Most users should stay on `latest`; use `edge` only when ye intentionally want the newest successful `main` build before it becomes a stable release.
 
-| 📦 Registry | 🏷️ Image |
-| --- | --- |
-| GHCR | `ghcr.io/scottgigawatt/privateerr:latest` |
-| Docker Hub | `scottgigawatt/privateerr:latest` |
+| 📦 Registry | ✅ Stable | 🧪 Edge |
+| --- | --- | --- |
+| GHCR | `ghcr.io/scottgigawatt/privateerr:latest` | `ghcr.io/scottgigawatt/privateerr:edge` |
+| Docker Hub | `scottgigawatt/privateerr:latest` | `scottgigawatt/privateerr:edge` |
+
+Stable version tags such as `1.0.0` remain available when ye need to pin an exact release. Commit tags such as `sha-cfa2fb5` identify a particular source revision. Prerelease tags keep their own version and never replace `latest`.
 
 The Docker Hub overview is generated from [docs/DOCKERHUB_README.md](./docs/DOCKERHUB_README.md), which keeps Docker Hub focused on pulling the image and understanding the basic use case. The full project docs stay here in the GitHub README.
 
@@ -233,9 +235,10 @@ Privateerr keeps the build deck intentionally locked down:
 - Alpine build bases are pinned to versioned image digests.
 - Renovate opens update PRs for pinned actions, Docker digests, Compose images, and submodules.
 - Pre-commit, CodeQL, OpenSSF Scorecard, and Trivy guard the repo and image workflow.
-- Release images are built on `main`, scanned with Trivy before publish, attested, and mirrored from GHCR to Docker Hub with digest preservation.
+- Successful `main` builds publish `edge`; stable semantic-version tags publish the exact version and move `latest`.
+- Published images are scanned with Trivy, attested, and mirrored from GHCR to Docker Hub with digest preservation.
 
-This means a new `main` build does **not** silently float to a newer Alpine base just because Alpine published one. Renovate has to raise the flag, CI has to pass, and the update has to merge before the next published image uses that new base.
+This means a new `main` build does **not** replace the stable `latest` image or silently float to a newer Alpine base just because Alpine published one. Renovate has to raise the flag, CI has to pass, and the update has to merge before `edge` uses that new base. A reviewed version tag is still required to move `latest`.
 
 ## ⚖️ License And Community
 

--- a/docs/ADVANCED_USAGE.md
+++ b/docs/ADVANCED_USAGE.md
@@ -63,6 +63,16 @@ The `build-and-push` GitHub Actions workflow builds and publishes Privateerr to 
 | GHCR | `ghcr.io/${{ github.repository_owner }}/privateerr` | The test-only Buccaneerr image is also published here for CI and release validation. |
 | Docker Hub | `docker.io/${{ github.repository_owner }}/privateerr` | Docker Hub is focused on the user-facing Privateerr image. |
 
+Both registries use the same release channels:
+
+| 🏷️ Source | 📦 Published tags | 🧭 Purpose |
+| --- | --- | --- |
+| Successful `main` build | `edge`, `sha-<commit>` | Preview the newest reviewed code without changing the stable channel. |
+| Stable tag such as `v1.2.3` | `1.2.3`, `latest`, `sha-<commit>` | Publish an exact stable version and advance the recommended channel. |
+| Prerelease tag such as `v1.2.3-rc.1` | `1.2.3-rc.1`, `sha-<commit>` | Publish a testable prerelease without changing `latest`. |
+
+Release tags must use semantic versioning, be annotated, and point to a commit on `main`. A manual workflow run may publish only from `main`. The workflow validates those rules before it logs in to the registries or publishes an image.
+
 The workflow uses Docker Buildx to create the canonical GHCR image:
 
 ```yaml
@@ -104,7 +114,7 @@ Renovate keeps those pins from going stale. It tracks:
 When Renovate opens a dependency PR, the validation workflow checks that every pinned `ALPINE_TAG` value still matches across Dockerfiles, workflow build args, and the example environment file. If one build arg drifts away from the fleet, `check-alpine-tag-pins.sh` fails before the PR can merge.
 
 > [!NOTE]
-> 🧭 `latest` remains a published image tag for users. It is not used as the release build's Alpine base. The base image is intentionally pinned and moved by reviewed Renovate PRs.
+> 🧭 `latest` remains the recommended stable image tag for users, while `edge` follows successful `main` builds. Neither tag is used as the Alpine base. The base image is intentionally pinned and moved by reviewed Renovate PRs.
 
 ## 🛠️ Useful Maintenance Commands
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,6 +61,16 @@ pre-commit run --all-files
 - Keep service config directories aligned with service names.
 - Leave upstream PIA scripts untouched so users can verify the treasure scrolls were not tampered with.
 
+## Release Tags 🏷️
+
+- Create annotated release tags from commits already on `main`.
+- Use semantic versions such as `v1.2.3` or `v1.2.3-rc.1`.
+- Never move or reuse a published version tag.
+- Successful `main` builds publish `edge`; they do not replace `latest`.
+- Stable version tags publish the exact version and replace `latest`.
+- Prerelease tags publish only the prerelease version and commit SHA tags.
+- Wait for the image workflow, registry mirror, and provenance checks before publishing the GitHub release.
+
 ## Pull Requests 🪝
 
 Before opening a pull request:

--- a/docs/DOCKERHUB_README.md
+++ b/docs/DOCKERHUB_README.md
@@ -11,6 +11,21 @@ Privateerr is a tiny Docker wrapper that packages the original, unmodified [pia-
 docker pull scottgigawatt/privateerr:latest
 ```
 
+`latest` is the newest stable release. To test the newest successful build from `main` before it becomes a release, opt in to `edge`:
+
+```console
+docker pull scottgigawatt/privateerr:edge
+```
+
+| 🏷️ Tag | 🧭 Purpose |
+| --- | --- |
+| `latest` | Newest stable semantic-version release; recommended for most users. |
+| `1.0.0` | A specific stable release. |
+| `edge` | Newest successful `main` build; may change before the next release. |
+| `sha-cfa2fb5` | Image built from a specific source commit. |
+
+Prerelease versions keep their own tags and never replace `latest`.
+
 Published tags are multi-architecture manifests for:
 
 | 🧱 Platform | 🖥️ Typical use |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,13 +4,13 @@ Ahoy, security-minded sailor. If ye spot a cursed leak, a leaky hull, or a suspi
 
 ## Supported Versions ⚓
 
-Privateerr sails mostly by the `main` branch and the latest published container images. Since this project be a small vessel, security fixes target the newest chart instead of older treasure maps.
+Privateerr sails by the stable `latest` image and the `edge` image built from `main`. Since this project be a small vessel, security fixes target those newest charts instead of older treasure maps.
 
 | Version | Supported |
 | ------- | --------- |
-| `latest` image | ✅ |
-| `main` branch | ✅ |
-| Older local builds | ❌ |
+| `latest` stable image | ✅ |
+| `edge` image and `main` branch | ✅ |
+| Older version tags and local builds | ❌ |
 | Forked or modified PIA scripts | ❌ |
 
 > [!IMPORTANT]
@@ -49,8 +49,8 @@ This be a small maintainer ship, not a giant navy. I will do my best to:
 
 - Acknowledge valid private reports within 7 days.
 - Triage severity and scope as soon as possible.
-- Patch accepted issues in `main`.
-- Publish a fresh image after a fix lands.
+- Patch accepted issues in `main` and publish the fix to `edge`.
+- Publish a stable semantic-version release when the fix is ready for `latest`.
 - Credit reporters when requested and safe to do so.
 
 If a report is declined, I will try to explain why without leakin' dangerous details into open waters.
@@ -67,12 +67,13 @@ The protected build path then:
 - Runs OpenSSF Scorecard on its own schedule and branch-protection events.
 - Builds Privateerr and Buccaneerr for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
 - Scans built images with Trivy before publishing.
-- Publishes images from `main` after checks pass.
+- Publishes `edge` from `main` after checks pass.
+- Publishes exact versions and `latest` from stable semantic-version tags.
 - Attests build provenance and mirrors Privateerr from GHCR to Docker Hub with digest preservation.
 
-Rebuilding the same commit does not automatically pick up a newer Alpine base. To pick up patched packages, merge the Renovate update PR first, then pull or publish a fresh image from the updated `main`.
+Rebuilding the same commit does not automatically pick up a newer Alpine base. To pick up patched packages, merge the Renovate update PR first, then pull `edge` from the updated `main` or publish a stable version tag when the change is ready for `latest`.
 
 > [!TIP]
-> 🏴‍☠️ For the freshest patched hull, pull the newest published image after dependency update PRs have merged.
+> 🏴‍☠️ Pull `latest` for the newest stable patched hull. Pull `edge` only when ye intentionally want the newest successful `main` build.
 
 Fair winds, sharp eyes, and may yer secrets stay below deck. ☠️

--- a/example.env
+++ b/example.env
@@ -22,6 +22,7 @@ DEFAULT_HEALTHCHECK_RETRIES="${DEFAULT_HEALTHCHECK_RETRIES:-3}"
 #
 # Privateerr service tag, build, and volume variables.
 #
+# Use latest for stable releases. Set edge only to test the newest main build.
 PRIVATEERR_TAG="${PRIVATEERR_TAG:-latest}"
 ALPINE_TAG="${ALPINE_TAG:-3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b}"
 PIA_BIN_HOME="${PIA_BIN_HOME:-/pia}"

--- a/example.env
+++ b/example.env
@@ -22,7 +22,6 @@ DEFAULT_HEALTHCHECK_RETRIES="${DEFAULT_HEALTHCHECK_RETRIES:-3}"
 #
 # Privateerr service tag, build, and volume variables.
 #
-# Use latest for stable releases. Set edge only to test the newest main build.
 PRIVATEERR_TAG="${PRIVATEERR_TAG:-latest}"
 ALPINE_TAG="${ALPINE_TAG:-3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b}"
 PIA_BIN_HOME="${PIA_BIN_HOME:-/pia}"

--- a/test/check-image-tag-policy.sh
+++ b/test/check-image-tag-policy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025-2026 Scott Gigawatt
+#
+# Licensed under the Apache License, Version 2.0.
+#
+# check-image-tag-policy.sh: Verify published image tags follow the release channel policy.
+#
+
+#
+# Fail on any error, unset variable, or failed pipe command.
+#
+set -euo pipefail
+
+#
+# Workflow path and expected rule counts for the Privateerr and Buccaneerr images.
+#
+workflow_path=".github/workflows/build-and-push.yml"
+expected_rule_count=2
+
+#
+# Count exact metadata-action rules without treating punctuation as expressions.
+#
+count_rule() {
+    local rule="$1"
+
+    grep -Fxc "${rule}" "${workflow_path}" || true
+}
+
+#
+# Require the same release channel rule in both image metadata blocks.
+#
+require_rule() {
+    local rule="$1"
+    local description="$2"
+    local rule_count
+
+    rule_count="$(count_rule "                      ${rule}")"
+    if [[ "${rule_count}" -ne "${expected_rule_count}" ]]; then
+        echo "Expected ${expected_rule_count} ${description} rules, found ${rule_count}."
+        exit 1
+    fi
+}
+
+require_rule "latest=auto" "stable latest"
+require_rule "type=edge,branch=main" "main edge"
+require_rule "type=sha,prefix=sha-" "commit SHA"
+require_rule "type=semver,pattern={{version}}" "semantic version"
+
+#
+# The latest tag must never be assigned directly from a branch or broad tag match.
+#
+if grep -Eq 'type=raw,value=latest|is_default_branch' "${workflow_path}"; then
+    echo "Raw latest rules are not allowed. Stable semantic versions own latest."
+    exit 1
+fi
+
+echo "Image tag policy is shipshape."


### PR DESCRIPTION
## Executive glamour shot 💅

- Publish successful `main` builds as `edge` instead of `latest`.
- Reserve `latest` for stable semantic-version releases while keeping prereleases isolated.
- Require release tags to be valid SemVer, annotated, and based on `main`.
- Restrict manual publishing to `main`.
- Add a pre-commit regression check so Privateerr and Buccaneerr cannot drift apart.
- Document the stable, edge, version, prerelease, and commit-SHA channels everywhere users encounter image tags.

## Why this mutiny was necessary 🏴‍☠️

The workflow explicitly assigned `latest` to the default branch and broadly assigned it to every `v...` tag. That allowed ordinary `main`, scheduled, or manual builds—and potentially prereleases—to replace the image users reasonably expect to be stable.

After this change, `main` serves preview couture through `edge`; stable version tags alone wear the `latest` crown.

## User and maintainer impact 🧭

- Existing users remain on the stable `latest` default.
- Testers can opt into `edge` for the newest successful `main` build.
- Exact versions and `sha-*` tags remain available for pinning and traceability.
- The existing live e2e secret/skip behavior is intentionally unchanged.

## Validation voyage 🧪

- `pre-commit run --all-files`
- `docker compose --env-file example.env -f docker-compose.yml config --quiet`
- `test/check-image-tag-policy.sh`
- `bash -n test/check-image-tag-policy.sh`
- `git diff --check`

All configured secret checks, YAML validation, actionlint, ShellCheck, Alpine pin checks, image-tag policy checks, and Dockerfile linting passed.